### PR TITLE
fix: restore wildcard registries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3073,7 +3073,9 @@ const buildConfigs = async (paths, ecosystem, registries, schedule) => {
     const configs = paths.map((path) => ({
         "package-ecosystem": `${ecosystem}`,
         directory: `${path != "." ? path : ""}/`,
-        ...(registries && { registries: [registries] }),
+        ...(registries && {
+            registries: registries == "*" ? registries : [registries],
+        }),
         schedule: { interval: `${schedule}` },
     }));
     configs.sort((a, b) => {

--- a/src/DependabotTypes.ts
+++ b/src/DependabotTypes.ts
@@ -146,7 +146,7 @@ export interface PackageEcosystem {
    * Disable automatic rebasing. 'auto' is the default and Dependabot will rebase open pull requests when changes are detected. 'disabled' will disable automatic rebasing.
    */
   "rebase-strategy"?: "auto" | "disabled"
-  registries?: [string, ...string[]]
+  registries?: [string, ...string[]] | "*"
   /**
    * Specify individual reviewers or teams of reviewers for all pull requests raised for a package manager. You must use the full team name, including the organization, as if you were @mentioning the team.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,9 @@ const buildConfigs = async (
   const configs: PackageEcosystem[] = paths.map((path) => ({
     "package-ecosystem": `${ecosystem}`,
     directory: `${path != "." ? path : ""}/`,
-    ...(registries && { registries: [registries] }),
+    ...(registries && {
+      registries: registries == "*" ? registries : [registries],
+    }),
     schedule: { interval: `${schedule}` },
   }))
 


### PR DESCRIPTION
### **Why** is the change needed?

```yaml
registries:
 - * 
```

is apparently not allowed 🤷🏻 
types generated from https://json.schemastore.org/dependabot-2.0.json didn't keep the option to assign `'*'` as registries 

```json
        "registries": {
          "$comment": "'registries' must be either an array of strings, or the string constant '*'.",
          "oneOf": [
            {
              "type": "array",
              "items": {
                "type": "string",
                "minLength": 1
              },
              "uniqueItems": true,
              "minItems": 1
            },
            {
              "type": "string",
              "const": "*"
            }
          ]
        },
```
